### PR TITLE
Add torchvision for the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pymongo
 msgpack
 msgpack-numpy
 lz4
+torchvision


### PR DESCRIPTION
## Description
As title.

I have successfully ran the `python train.py` in my local laptop fortunately.
However, the torchvision was not in the requirements, which was necessary for the mnist run.
I am leaving my pip freeze which successfully ran the mnist data as for record for other contributors:
```
certifi==2023.7.22
charset-normalizer==3.3.1
dnspython==2.4.2
einops==0.7.0
filelock==3.12.4
fsspec==2023.10.0
idna==3.4
Jinja2==3.1.2
lz4==4.3.2
MarkupSafe==2.1.3
mpmath==1.3.0
msgpack==1.0.7
msgpack-numpy==0.4.8
networkx==3.2
numpy==1.26.1
Pillow==10.1.0
pymongo==4.5.0
PyYAML==6.0.1
requests==2.31.0
sympy==1.12
torch==2.1.0
torchvision==0.16.0
typing_extensions==4.8.0
urllib3==2.0.7
```

## Test Plan
Local test.