### PR TITLE
Eliminating entry for loop to look for `data_id`.

### DIFF
--- a/analog/storage/default.py
+++ b/analog/storage/default.py
@@ -113,7 +113,9 @@ class DefaultStorageHandler(StorageHandlerBase):
         if len(self.buffer) == 0:
             return self.log_dir
         buffer_list = [(k, v) for k, v in self.buffer.items()]
-        self.mmap_handler.write(buffer_list, self.file_prefix + f"{self.push_count}.mmap")
+        self.mmap_handler.write(
+            buffer_list, self.file_prefix + f"{self.push_count}.mmap"
+        )
 
         self.push_count += 1
         del buffer_list
@@ -223,9 +225,7 @@ class DefaultLogDataset(Dataset):
                 chunk_indices.append(int(chunk_index))
         return sorted(chunk_indices)
 
-    def _add_metadata_and_mmap(
-        self, mmap_filename, chunk_index
-    ):
+    def _add_metadata_and_mmap(self, mmap_filename, chunk_index):
         # Load the memmap file
         mmap, metadata = self.mmap_handler.read(mmap_filename)
         self.memmaps.append(mmap)
@@ -239,6 +239,7 @@ class DefaultLogDataset(Dataset):
                 self.data_id_to_chunk[data_id][1].append(entry)
                 continue
             self.data_id_to_chunk[data_id] = (chunk_index, [entry])
+
     def __getitem__(self, index):
         data_id = list(self.data_id_to_chunk.keys())[index]
         chunk_idx, entries = self.data_id_to_chunk[data_id]

--- a/analog/storage/utils.py
+++ b/analog/storage/utils.py
@@ -27,7 +27,7 @@ def extract_arrays(obj, base_path=()):
 
 
 class MemoryMapHandler:
-    def __init__(self, log_dir, mmap_dtype='uint8'):
+    def __init__(self, log_dir, mmap_dtype="uint8"):
         """
         Args:
             save_path (str): The directory of the path to write and read the binaries and the metadata.
@@ -47,8 +47,12 @@ class MemoryMapHandler:
         mmap_filename = os.path.join(self.save_path, filename)
         metadata_filename = os.path.join(self.save_path, file_root + "_metadata.json")
 
-        total_size = sum(arr.nbytes for _, d in data_buffer for _, arr in extract_arrays(d))
-        mmap = np.memmap(mmap_filename, dtype=self.mmap_dtype, mode="w+", shape=(total_size,))
+        total_size = sum(
+            arr.nbytes for _, d in data_buffer for _, arr in extract_arrays(d)
+        )
+        mmap = np.memmap(
+            mmap_filename, dtype=self.mmap_dtype, mode="w+", shape=(total_size,)
+        )
 
         metadata = []
         offset = 0
@@ -56,7 +60,7 @@ class MemoryMapHandler:
         for data_id, nested_dict in data_buffer:
             for path, arr in extract_arrays(nested_dict):
                 bytes = arr.nbytes
-                mmap[offset: offset + bytes] = arr.ravel().view(self.mmap_dtype)
+                mmap[offset : offset + bytes] = arr.ravel().view(self.mmap_dtype)
                 metadata.append(
                     {
                         "data_id": data_id,
@@ -88,7 +92,9 @@ class MemoryMapHandler:
         if file_ext == "":
             filename += ".mmap"
 
-        mmap = np.memmap(os.path.join(self.save_path, filename), dtype=self.mmap_dtype, mode="r")
+        mmap = np.memmap(
+            os.path.join(self.save_path, filename), dtype=self.mmap_dtype, mode="r"
+        )
         metadata = self.read_metafile(file_root + "_metadata.json")
         return mmap, metadata
 


### PR DESCRIPTION
Currently, the `self.data_id_to_chunk[data_id]` variable only saves the chunk index and the downstream retrieves the schema(metadata) via `self.schemas`, a list that has all the schema dumped as a List type.

Now, `self.data_id_to_chunk[data_id]` will have tuple of chunk index and schema list corresponding to the `data_id`, which will be easier to handle. 
I have checked the run in the local machine, should be not hike the memory pressure as we remove one of the attribute.
