### PR TITLE
remove squeeze

### DIFF
--- a/analog/analysis/influence_function.py
+++ b/analog/analysis/influence_function.py
@@ -65,7 +65,7 @@ class InfluenceFunction(AnalysisBase):
             module_influence = reduce(
                 src_log_expanded * tgt_log_expanded, "n m a b -> n m", "sum"
             )
-            total_influence += module_influence.squeeze()
+            total_influence += module_influence
         return total_influence
 
     def compute_self_influence(self, src, damping=None):


### PR DESCRIPTION
This squeeze operation causes a bug when test batch size is 1. The batch size for the last batch could be sometimes be 1.
`module_influence` is a tensor of shape (test_size, test_size), so we should not squeeze here.