### PR TITLE
Fix typo and EK-FAC scaling

### DIFF
--- a/analog/hessian/kfac.py
+++ b/analog/hessian/kfac.py
@@ -106,7 +106,7 @@ class KFACHessianHandler(HessianHandlerBase):
             # By default, the hessian state is stored on the CPU. However,
             # computing/updating the hessian state is on CPU is slow. Thus,
             # we move the hessian state to the GPU if the activation is on
-            # the GPU, and then move it back to the CPU asynchrously.
+            # the GPU, and then move it back to the CPU asynchronously.
             hessian_state_gpu = hessian_state[module_name][mode].to(
                 device=activations.device
             )
@@ -142,5 +142,5 @@ class KFACHessianHandler(HessianHandlerBase):
             weight = torch.matmul(
                 hessian_eigvec_state[module_name][BACKWARD].t(), rotated_grad
             )
-            ekfac_eigval_state[module_name].add_(torch.square(weight), alpha=0.5)
+            ekfac_eigval_state[module_name].add_(torch.square(weight), alpha=1.0)
         ekfac_counter[module_name] += len(data)


### PR DESCRIPTION
I fixed one very minor typo. For the EK-FAC computation, I believe that we shouldn't multiply the Lambda by 0.5; it probably does not matter for the overall computation (unless it is very sensitive to the damping term). Please let me know if my understanding is incorrect.