### PR TITLE
Fix inplace reshaping of activations/grad inside hooks

### DIFF
--- a/analog/hessian/kfac.py
+++ b/analog/hessian/kfac.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from analog.constants import FORWARD, BACKWARD
 from analog.state import AnaLogState
 from analog.hessian.base import HessianHandlerBase
-from analog.hessian.utils import extract_actvations_expand, extract_actvations_reduce
+from analog.hessian.utils import extract_activations_expand, extract_activations_reduce
 
 
 class KFACHessianHandler(HessianHandlerBase):
@@ -54,7 +54,7 @@ class KFACHessianHandler(HessianHandlerBase):
             return
 
         # extract activations
-        activations = extract_actvations_reduce(module, mode, data).detach()
+        activations = extract_activations_reduce(module, mode, data).detach()
 
         # update hessian
         self.update_hessian(module_name, mode, activations)
@@ -70,7 +70,7 @@ class KFACHessianHandler(HessianHandlerBase):
             return
 
         # extract activations
-        activations = extract_actvations_expand(module, mode, data).detach()
+        activations = extract_activations_expand(module, mode, data).detach()
 
         # update hessian
         self.update_hessian(module_name, mode, activations)

--- a/analog/hessian/utils.py
+++ b/analog/hessian/utils.py
@@ -44,7 +44,7 @@ def extract_patches(
     inputs = inputs.unfold(2, kernel_size[0], stride[0])
     inputs = inputs.unfold(3, kernel_size[1], stride[1])
     inputs = inputs.transpose_(1, 2).transpose_(2, 3).contiguous()
-    inputs = inputs.view(
+    inputs = inputs.reshape(
         inputs.size(0),
         inputs.size(1),
         inputs.size(2),
@@ -71,7 +71,7 @@ def extract_forward_activations(
         reshaped_activations = extract_patches(
             activations, module.kernel_size, module.stride, module.padding
         )
-        reshaped_activations = reshaped_activations.view(
+        reshaped_activations = reshaped_activations.reshape(
             -1, reshaped_activations.size(-1)
         )
     else:
@@ -104,7 +104,7 @@ def extract_backward_activations(
     return reshaped_grads
 
 
-def extract_actvations_expand(module: nn.Module, mode: str, activations: torch.Tensor):
+def extract_activations_expand(module: nn.Module, mode: str, activations: torch.Tensor):
     """Extract activations in an expanded mode for the KFAC approximation.
 
     Args:
@@ -123,7 +123,7 @@ def extract_actvations_expand(module: nn.Module, mode: str, activations: torch.T
         raise ValueError(f"Invalid mode {mode}")
 
 
-def extract_actvations_reduce(module: nn.Module, mode: str, activations: torch.Tensor):
+def extract_activations_reduce(module: nn.Module, mode: str, activations: torch.Tensor):
     """Extract activations in an expanded mode for the KFAC approximation.
 
     Args:

--- a/analog/logging.py
+++ b/analog/logging.py
@@ -110,7 +110,7 @@ class LoggingHandler:
         # If KFAC is used, update the forward covariance
         if config["hessian"] and self.hessian_type == "kfac":
             self.hessian_handler.update_hessian_expand(
-                module, module_name, FORWARD, activations
+                module, module_name, FORWARD, activations.clone()
             )
 
         if FORWARD in config["log"]:
@@ -143,7 +143,7 @@ class LoggingHandler:
         # If KFAC is used, update the backward covariance
         if config["hessian"] and self.hessian_type == "kfac":
             self.hessian_handler.update_hessian_expand(
-                module, module_name, BACKWARD, grad_outputs[0]
+                module, module_name, BACKWARD, grad_outputs[0].clone()
             )
 
         if BACKWARD in config["log"]:


### PR DESCRIPTION
PyTorch complains when the views of the activations and gradients are moved around. Cloning them instead to avoid warnings and making sure to reshape instead of view. 