### PR TITLE
add lora when resuming

### DIFF
--- a/analog/analog.py
+++ b/analog/analog.py
@@ -380,7 +380,8 @@ class AnaLog:
         # Load LoRA state
         lora_dir = os.path.join(self.log_dir, "lora")
         if os.path.exists(lora_dir):
-            self.add_lora()
+            if not any("analog_lora_A" in name for name in self.model.state_dict()):
+                self.add_lora()
             lora_state = torch.load(os.path.join(lora_dir, "lora_state_dict.pt"))
             for name in lora_state:
                 assert name in self.model.state_dict(), f"{name} not in model!"


### PR DESCRIPTION
I was trying to `initlaize_from_log` with BERT model and found that we need to add lora modules before loading the saved lora state dict.
We run into this error with the current code in the main branch.
```python
Traceback (most recent call last):
  File "/data/tir/projects/tir6/general/hahn2/analog/examples/bert_influence/compute_influence.py", line 106, in <module>
    analog.initialize_from_log()
  File "/data/tir/projects/tir6/general/hahn2/analog/analog/analog.py", line 385, in initialize_from_log
    assert name in self.model.state_dict(), f"{name} not in model!"
AssertionError: model.bert.encoder.layer.0.attention.self.query.analog_lora_A.weight not in model!
```