### PR TITLE
Resolve deadlock during synchronization

### DIFF
--- a/analog/__init__.py
+++ b/analog/__init__.py
@@ -31,14 +31,81 @@ def init(project: str, config: str = "./config.yaml"):
     return run
 
 
-if _ANALOG_INSTANCE is not None:
-    add_analysis = _ANALOG_INSTANCE.add_analysis
-    add_lora = _ANALOG_INSTANCE.add_lora
-    build_log_dataloader = _ANALOG_INSTANCE.build_log_dataloader
-    clear = _ANALOG_INSTANCE.clear
-    eval = _ANALOG_INSTANCE.eval
-    finalize = _ANALOG_INSTANCE.finalize
-    log = _ANALOG_INSTANCE.log
-    setup = _ANALOG_INSTANCE.setup
-    watch = _ANALOG_INSTANCE.watch
-    watch_activation = _ANALOG_INSTANCE.watch_activation
+def add_analysis(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.add_analysis(*args, **kwargs)
+
+
+def add_lora(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.add_lora(*args, **kwargs)
+
+
+def build_log_dataloader(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.build_log_dataloader(*args, **kwargs)
+
+
+def clear(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.clear(*args, **kwargs)
+
+
+def eval(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.eval(*args, **kwargs)
+
+
+def finalize(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.finalize(*args, **kwargs)
+
+
+def log(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.log(*args, **kwargs)
+
+
+def setup(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.setup(*args, **kwargs)
+
+
+def watch(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.watch(*args, **kwargs)
+
+
+def watch_activation(*args, **kwargs):
+    if _ANALOG_INSTANCE is None:
+        raise RuntimeError(
+            "AnaLog is not initialized. You must call analog.init() first."
+        )
+    return _ANALOG_INSTANCE.watch_activation(*args, **kwargs)

--- a/analog/state.py
+++ b/analog/state.py
@@ -14,10 +14,10 @@ class StatisticState:
     """
 
     def __init__(self) -> None:
-        self._states = set()
-        self._states_to_synchronize = set()
-        self._states_to_save = set()
-        self._states_to_normalize = set()
+        self._states = []
+        self._states_to_synchronize = []
+        self._states_to_save = []
+        self._states_to_normalize = []
 
         self.register_state("mean_state", synchronize=True, save=True)
         self.register_state("mean_counter", synchronize=True, save=False)
@@ -38,20 +38,20 @@ class StatisticState:
 
         assert state_name not in self._states
         setattr(self, state_name, nested_dict())
-        self._states.add(state_name)
+        self._states.append(state_name)
         if synchronize:
-            self._states_to_synchronize.add(state_name)
+            self._states_to_synchronize.append(state_name)
         if save:
-            self._states_to_save.add(state_name)
+            self._states_to_save.append(state_name)
 
     def register_normalize_pair(self, state_name: str, counter_name: str):
         """
-        Add a normalization to the state.
+        Add a normalization pair to the state.
         """
         if (state_name, counter_name) in self._states_to_normalize:
             return
 
-        self._states_to_normalize.add((state_name, counter_name))
+        self._states_to_normalize.append((state_name, counter_name))
 
     @torch.no_grad()
     def covariance_svd(self) -> None:


### PR DESCRIPTION
In the previous code, the code got stuck randomly at `torch.cuda.synchronize()` in `state.py`. You can reproduce this random deadlock by running

```bash
python examples/mnist_influnece/compute_influences_distributed.py
```

Upon debugging, this is due to the use of `set()` for saving various states in `state.py`. As Python set lacks ordering among its elements, different processes tried to synchronize different states (e.g. rank 0: covariance_state, rank 1: covariance_counter), and this silently caused deadlock. I was able to find this bug with `TORCH_DISTRIBUTED_DEBUG=DETAIL`. 

In addition, I improved `__init__` and confirmed that users can now do:

```python
import analog

analog.init(project="test")

analog.watch(model)
analog.setup({"log": "grad", "statistic": "kfac"})
```