### PR TITLE
do not overwrite index

### DIFF
--- a/analog/analysis/influence_function.py
+++ b/analog/analysis/influence_function.py
@@ -79,7 +79,8 @@ class InfluenceFunction(AnalysisBase):
             assert total_influence.shape[1] == len(tgt_ids)
             # Ensure src_ids and tgt_ids are in the DataFrame's index and columns, respectively
             self.influence_scores = self.influence_scores.reindex(
-                index=src_ids, columns=tgt_ids
+                index=self.influence_scores.index.union(src_ids),
+                columns=self.influence_scores.columns.union(tgt_ids),
             )
 
             # Assign total_influence values to the corresponding locations in influence_scores


### PR DESCRIPTION
This is a small fix to allow saving IF score for multiple batches.
The bug was that previous code only saved IF score for the last batch.
