### PR TITLE
fix normalization by number of examples

### DIFF
--- a/analog/statistic/covariance.py
+++ b/analog/statistic/covariance.py
@@ -28,6 +28,7 @@ class Covariance:
             data = binfo.log[module_name][log_type]
 
         # extract and reshape data to 2d tensor for mean computation
+        batch_size = data.size(0)
         data = make_2d(data, module, log_type).detach()
 
         # initialize covariance state if necessary
@@ -55,6 +56,6 @@ class Covariance:
 
         # update mean counter
         if binfo.mask is None or log_type == "grad":
-            covariance_counter[module_name][log_type] += len(data)
+            covariance_counter[module_name][log_type] += batch_size
         else:
             covariance_counter[module_name][log_type] += binfo.mask.sum().item()

--- a/analog/statistic/mean.py
+++ b/analog/statistic/mean.py
@@ -28,6 +28,7 @@ class Mean:
             data = binfo.log[module_name][log_type]
 
         # extract and reshape data to 2d tensor for mean computation
+        batch_size = data.size(0)
         data = make_2d(data, module, log_type).detach()
 
         # initialize mean state if necessary
@@ -51,6 +52,6 @@ class Mean:
 
         # update mean counter
         if binfo.mask is None or log_type == "grad":
-            mean_counter[module_name][log_type] += len(data)
+            mean_counter[module_name][log_type] += batch_size
         else:
             mean_counter[module_name][log_type] += binfo.mask.sum().item()


### PR DESCRIPTION
This PR corrects how to get the number of examples from a batch.
The bug is that `len(data)` does not give the number of examples as it is reshaped to 2d matrix of (bs*seq_len, feat_dim) in line 32.