### PR TITLE
Optimization for compute_influence part

### DIFF
--- a/analog/analysis/influence_function.py
+++ b/analog/analysis/influence_function.py
@@ -149,12 +149,8 @@ class InfluenceFunction:
         )
 
         # Assign total_influence values to the corresponding locations
-        src_indices = [
-            self.influence_scores.index.get_loc(src_id) for src_id in src_ids
-        ]
-        tgt_indices = [
-            self.influence_scores.columns.get_loc(tgt_id) for tgt_id in tgt_ids
-        ]
+        src_indices = self.influence_scores.index.get_indexer(src_ids)
+        tgt_indices = self.influence_scores.columns.get_indexer(tgt_ids)
 
         self.influence_scores.iloc[src_indices, tgt_indices] = total_influence.numpy()
 


### PR DESCRIPTION
## Summary
Optimization for the influence function tgt indexer when running with 10 src_ids and 10,000,000 tgt_ids.

This change will make twice as faster.

Note since Pandas runs above Numpy, it is faster than the native python list[] or even dictionary {}.
We can further optimize this using only c-python I think.

I also tested that  {} search operation was slower than `influence_scores.index.get_loc(src_id)` as well as creating the dictionary map

## Related Issues
Stated above.

## Test Plan
https://colab.research.google.com/drive/18_M8zA8RB-CDZ7jfUOFELS3DK35yaMlE#scrollTo=GNVYnz-Uo2VS
The operation got twice as faster.