### PR TITLE
Update logging setup interface

### DIFF
--- a/examples/bert/compute_influence.py
+++ b/examples/bert/compute_influence.py
@@ -35,7 +35,7 @@ def main():
     log_loader = logix.build_log_dataloader()
 
     # influence analysis
-    logix.setup({"log": "grad"})
+    logix.setup({"grad": ["log"]})
     logix.eval()
     for batch in test_loader:
         data_id = tokenizer.batch_decode(batch["input_ids"])

--- a/examples/cifar/compute_influences.py
+++ b/examples/cifar/compute_influences.py
@@ -64,7 +64,7 @@ for epoch in logix_scheduler:
 log_loader = logix.build_log_dataloader()
 
 logix.eval()
-logix.setup({"log": "grad"})
+logix.setup({"grad": ["log"]})
 for test_input, test_target in test_loader:
     with logix(data_id=id_gen(test_input)):
         test_input, test_target = test_input.to(DEVICE), test_target.to(DEVICE)

--- a/examples/language_modeling/compute_influence.py
+++ b/examples/language_modeling/compute_influence.py
@@ -74,7 +74,7 @@ def main():
     log_loader = logix.build_log_dataloader(batch_size=64)
 
     # Influence analysis
-    logix.setup({"log": "grad"})
+    logix.setup({"grad": ["log"]})
     logix.eval()
     merged_test_logs = []
     for idx, batch in enumerate(tqdm(data_loader)):

--- a/examples/mnist/compute_influences.py
+++ b/examples/mnist/compute_influences.py
@@ -62,7 +62,7 @@ log_loader = logix.build_log_dataloader(
 )
 
 # logix.add_analysis({"influence": InfluenceFunction})
-logix.setup({"log": "grad"})
+logix.setup({"grad": ["log"]})
 logix.eval()
 for test_input, test_target in test_loader:
     with logix(data_id=id_gen(test_input)):

--- a/examples/mnist/compute_influences_manual.py
+++ b/examples/mnist/compute_influences_manual.py
@@ -67,7 +67,7 @@ log_loader = logix.build_log_dataloader(
 )
 
 # logix.add_analysis({"influence": InfluenceFunction})
-logix.setup({"log": "grad"})
+logix.setup({"grad": ["log"]})
 logix.eval()
 for test_input, test_target in test_loader:
     ### Start

--- a/logix/huggingface/callback.py
+++ b/logix/huggingface/callback.py
@@ -46,7 +46,7 @@ class LogIXCallback(TrainerCallback):
             self.logix.initialize_from_log()
 
         if self.args.mode in ["influence", "self_influence"]:
-            self.logix.setup({"log": "grad"})
+            self.logix.setup({"grad": ["log"]})
             self.logix.eval()
 
             state.epoch = 0

--- a/logix/statistic/log.py
+++ b/logix/statistic/log.py
@@ -22,7 +22,7 @@ class Log:
         """
         Put log into `binfo`
         """
-        module_log = binfo[module_name]
+        module_log = binfo.log[module_name]
         if log_type not in module_log:
             module_log[log_type] = data
         else:

--- a/tests/examples/test_compute_influences.py
+++ b/tests/examples/test_compute_influences.py
@@ -112,6 +112,7 @@ class TestSingleCheckpointInfluence(unittest.TestCase):
         # logix.add_analysis({"influence": InfluenceFunction})
         query_iter = iter(query_loader)
         logix.eval()
+        logix.setup({"grad": ["log"]})
         with logix(data_id=["test"]) as al:
             test_input, test_target = next(query_iter)
             test_input, test_target = test_input.to(DEVICE), test_target.to(DEVICE)


### PR DESCRIPTION
This is a proposal to clean up the logging setup interface. Previously, `logix.setup` used to have three keys of `log`, `save`, and `statistic`, and within `statistic` we additionally `forward`, `backward`, and `grad`. In fact, we only need three keys of `forward`, `backward`, and `grad` as we show below:

```python
from logix.statistic import Log, Covariance

# before
run.setup({"log": "grad", "save": "grad", "statistic": {"forward": [], "backward": [], "grad": [Covariance]}})

# after
run.setup({"forward": [], "bakcward": [], "grad": [Log, Covariance]})
```

An additional change we introduce is separating `save` from the logging setup. Instead users can enable saving both globally (dataset-level) or locally (batch-level) as below:

```python
# global
run.save(True) # run.save(False)

# local
with run(data_id=data_id, save=True):
    ...
```

I believe this interface would ease users to more easily define and plug-in their own statistics computation primitives. 